### PR TITLE
Aggiunto ANT build per compilare senza Eclipse e istruzioni per iniziare su ambiente Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ script di configurazione ANT da terminale. In particolare:
 ```
 # Entrare nella cartella del progetto
 cd TablutCompetition/Tablut
+```
 
-# Un modo per capire se si e' nella cartella giusta e'
-# verificare che sia presente il file build.xml
+Un modo per capire se si e' nella cartella giusta e' verificare che sia presente il file build.xml
 
-# A questo punto, per compilare il progetto
+A questo punto, per compilare il progetto:
+
+```
 ant clean
 ant compile
 ```
@@ -55,42 +57,5 @@ ant randomblack
 ```
 
 A questo punto, si dovrebbe aprire una finestra che mostra graficamente lo
-stato della parti
-
-## Eseguire il Server senza utilizzare Eclipse
-
-Il metodo piu' comodo per eseguire il server consiste nell'utilizzare lo
-script di configurazione ANT da terminale. In particolare:
-
-```
-# Entrare nella cartella del progetto
-cd TablutCompetition/Tablut
-
-# Un modo per capire se si e' nella cartella giusta e'
-# verificare che sia presente il file build.xml
-
-# A questo punto, per compilare il progetto
-ant clean
-ant compile
-```
-
-Il progetto e' stato compilato nella cartella `build`. Per lanciare il server
-si puo' utilizzare il comando:
-
-```
-ant server
-```
-
-Per provarne il funzionamento, si possono attivare i due giocatori Random:
-
-```
-# Da altre due finestre di terminale
-ant randomwhite
-
-# E nell'altra
-ant randomblack
-```
-
-A questo punto, si dovrebbe aprire una finestra che mostra graficamente lo
-stato della partita. 
+stato della partita.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,96 @@
 # TablutCompetition
 Software for the Tablut Students Competition
+
+## Installazione su Ubuntu/Debian 
+
+Queste sono le istruzioni per installare le librerie necessarie su ambiente
+ubuntu/debian:
+
+Da terminale, eseguire i seguenti comandi per installare JDK 8 e ANT.
+
+```
+sudo apt update
+sudo apt install openjdk-8-jdk -y
+sudo apt install ant -y
+```
+
+A questo punto, bisogna clonare la repository del progetto.
+
+```
+git clone https://github.com/AGalassi/TablutCompetition.git
+```
+
+## Eseguire il Server senza utilizzare Eclipse
+
+Il metodo piu' comodo per eseguire il server consiste nell'utilizzare lo
+script di configurazione ANT da terminale. In particolare:
+
+```
+# Entrare nella cartella del progetto
+cd TablutCompetition/Tablut
+
+# Un modo per capire se si e' nella cartella giusta e'
+# verificare che sia presente il file build.xml
+
+# A questo punto, per compilare il progetto
+ant clean
+ant compile
+```
+
+Il progetto e' stato compilato nella cartella `build`. Per lanciare il server
+si puo' utilizzare il comando:
+
+```
+ant server
+```
+
+Per provarne il funzionamento, si possono attivare i due giocatori Random:
+
+```
+# Da altre due finestre di terminale
+ant randomwhite
+
+# E nell'altra
+ant randomblack
+```
+
+A questo punto, si dovrebbe aprire una finestra che mostra graficamente lo
+stato della parti
+
+## Eseguire il Server senza utilizzare Eclipse
+
+Il metodo piu' comodo per eseguire il server consiste nell'utilizzare lo
+script di configurazione ANT da terminale. In particolare:
+
+```
+# Entrare nella cartella del progetto
+cd TablutCompetition/Tablut
+
+# Un modo per capire se si e' nella cartella giusta e'
+# verificare che sia presente il file build.xml
+
+# A questo punto, per compilare il progetto
+ant clean
+ant compile
+```
+
+Il progetto e' stato compilato nella cartella `build`. Per lanciare il server
+si puo' utilizzare il comando:
+
+```
+ant server
+```
+
+Per provarne il funzionamento, si possono attivare i due giocatori Random:
+
+```
+# Da altre due finestre di terminale
+ant randomwhite
+
+# E nell'altra
+ant randomblack
+```
+
+A questo punto, si dovrebbe aprire una finestra che mostra graficamente lo
+stato della partita. 
+

--- a/Tablut/build.xml
+++ b/Tablut/build.xml
@@ -1,0 +1,47 @@
+<!-- Le istruzioni su come usare ANT per eseguire il progetto, sono incluse nel file
+     di README, nella home del progetto -->
+
+<project name="Tablut">
+
+    <target name="clean">
+        <delete dir="build"/>
+    </target>
+
+    <target name="compile">
+        <mkdir dir="build"/>
+        <javac encoding="iso-8859-1" srcdir="src" 
+            destdir="build"
+            classpath="lib/gson-2.2.2.jar" />
+        <copy todir="build">
+            <fileset dir="src" excludes="*.java"/>
+        </copy>
+    </target>
+    
+    <target name="server">
+        <java classname="it.unibo.ai.didattica.competition.tablut.server.Server" fork="true">
+            <classpath>
+                <pathelement location="lib/gson-2.2.2.jar"/>
+                <pathelement location="build"/>
+            </classpath>
+        </java>
+    </target>
+    <target name="randomwhite">
+        <java classname="it.unibo.ai.didattica.competition.tablut.client.TablutRandomWhiteClient" fork="true">
+            <classpath>
+                <pathelement location="lib/gson-2.2.2.jar"/>
+                <pathelement location="build"/>
+            </classpath>
+        </java>
+    </target>
+    <target name="randomblack">
+        <java classname="it.unibo.ai.didattica.competition.tablut.client.TablutRandomBlackClient" fork="true">
+            <classpath>
+                <pathelement location="lib/gson-2.2.2.jar"/>
+                <pathelement location="build"/>
+            </classpath>
+        </java>
+    </target>
+
+
+
+</project>


### PR DESCRIPTION
Buongiorno @AGalassi ,

Viste le mie prime difficoltà nel far funzionare il progetto con Eclipse, ho realizzato un build script ANT che permette di compilare e lanciare server/random players da riga di comando molto semplicemente.

Ho aggiornato anche le istruzioni nel README per spiegare come utilizzarlo.

Credo possa essere utile a molti ragazzi che come me non vogliono farlo in Java, e per cui Eclipse risulta particolarmente scomodo.

Grazie,
Federico Terzi