### PR TITLE
Sostituzione delle chiamate writeUTF/readUTF con un'alternativa UTF8 standard.

### DIFF
--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/client/TablutClient.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/client/TablutClient.java
@@ -12,6 +12,7 @@ import com.google.gson.Gson;
 import it.unibo.ai.didattica.competition.tablut.domain.Action;
 import it.unibo.ai.didattica.competition.tablut.domain.State;
 import it.unibo.ai.didattica.competition.tablut.domain.StateTablut;
+import it.unibo.ai.didattica.competition.tablut.util.StreamUtils;
 
 /**
  * Classe astratta di un client per il gioco Tablut
@@ -83,20 +84,20 @@ public abstract class TablutClient implements Runnable {
 	 * Write an action to the server
 	 */
 	public void write(Action action) throws IOException, ClassNotFoundException {
-		out.writeUTF(this.gson.toJson(action));
+		StreamUtils.writeString(out, this.gson.toJson(action));
 	}
 	
 	/**
 	 * Write the name to the server
 	 */
 	public void declareName() throws IOException, ClassNotFoundException {
-		out.writeUTF(this.gson.toJson(this.name));
+		StreamUtils.writeString(out, this.gson.toJson(this.name));
 	}
 
 	/**
 	 * Read the state from the server
 	 */
 	public void read() throws ClassNotFoundException, IOException {
-		this.currentState = this.gson.fromJson(in.readUTF(), StateTablut.class);
+		this.currentState = this.gson.fromJson(StreamUtils.readString(in), StateTablut.class);
 	}
 }

--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/server/Server.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/server/Server.java
@@ -13,6 +13,7 @@ import java.util.logging.*;
 
 import it.unibo.ai.didattica.competition.tablut.domain.*;
 import it.unibo.ai.didattica.competition.tablut.gui.Gui;
+import it.unibo.ai.didattica.competition.tablut.util.StreamUtils;
 
 import com.google.gson.Gson;
 
@@ -244,7 +245,7 @@ public class Server implements Runnable {
 
 		public void run() {
 			try {
-				theGson = this.theStream.readUTF();
+				theGson = StreamUtils.readString(this.theStream);
 
 			} catch (Exception e) {
 			}
@@ -462,8 +463,8 @@ public class Server implements Runnable {
 
 		try {
 			theGson = gson.toJson(state);
-			whiteState.writeUTF(theGson);
-			blackState.writeUTF(theGson);
+			StreamUtils.writeString(whiteState, theGson);
+			StreamUtils.writeString(blackState, theGson);
 			loggSys.fine("Invio messaggio ai giocatori");
 			if (enableGui) {
 				theGui.update(state);
@@ -567,8 +568,8 @@ public class Server implements Runnable {
 			// SEND STATE TO PLAYERS
 			try {
 				theGson = gson.toJson(state);
-				whiteState.writeUTF(theGson);
-				blackState.writeUTF(theGson);
+				StreamUtils.writeString(whiteState, theGson);
+				StreamUtils.writeString(blackState, theGson);
 				loggSys.fine("Invio messaggio ai client");
 				if (enableGui) {
 					theGui.update(state);

--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/util/StreamUtils.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/util/StreamUtils.java
@@ -1,0 +1,33 @@
+package it.unibo.ai.didattica.competition.tablut.util;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class StreamUtils {
+	public static void writeString(DataOutputStream out, String s) throws IOException {
+		// Converti la stringa in un array di byte codificati con UTF-8
+		byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+		
+		// Invio la lunghezza dell'array di byte come intero
+		out.writeInt(bytes.length);
+		
+		// Invio l'array di byte
+		out.write(bytes, 0, bytes.length);
+	}
+	
+	public static String readString(DataInputStream in) throws IOException {
+		// Leggo la lunghezza dei byte in ingresso
+		int len = in.readInt();
+		
+		// Creo un array di bytes che conterra' i dati in ingresso
+		byte[] bytes = new byte[len];
+		
+		// Leggo TUTTI i bytes
+		in.readFully(bytes, 0, len);
+		
+		// Converto i bytes in tringa
+		return new String(bytes, StandardCharsets.UTF_8);
+	}
+}

--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/util/StreamUtils.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/util/StreamUtils.java
@@ -5,6 +5,23 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+/**
+ * Questa classe offre dei metodi per inviare e ricevere stringhe attraverso delle socket
+ * utilizzando l'encoding UTF-8.
+ * Questi metodi mirano a sostituire writeUTF/readUTF della classe DataOutputStream/DataInputStream
+ * che utilizzano un encoding UTF-8 modificato, proprio di java, che rende molto difficile 
+ * l'interfacciamento con altri linguaggi di programmazione.
+ * Fonte: https://docs.oracle.com/javase/7/docs/api/java/io/DataOutputStream.html#writeUTF(java.lang.String)
+ *  
+ * Per questo motivo, i metodi writeString/readString realizzano un approccio analogo a quello di
+ * writeUTF/readUTF ma utilizzando un encoding UTF-8 standard.
+ * 
+ * In particolare, inviano inizialmente sulla socket un intero ( 4 byte ) che rappresenta
+ * la lunghezza dei byte UTF-8 corrispondenti alla stringa, e poi successivamente invia i bytes.
+ * 
+ * In ricezione, si legge la lunghezza dell'array di byte, si legge l'array di bytes e si 
+ * converte il risultato in stringa.
+ */
 public class StreamUtils {
 	public static void writeString(DataOutputStream out, String s) throws IOException {
 		// Converti la stringa in un array di byte codificati con UTF-8
@@ -27,7 +44,7 @@ public class StreamUtils {
 		// Leggo TUTTI i bytes
 		in.readFully(bytes, 0, len);
 		
-		// Converto i bytes in tringa
+		// Converto i bytes in stringa
 		return new String(bytes, StandardCharsets.UTF_8);
 	}
 }


### PR DESCRIPTION
Buongiorno @AGalassi 

Come gia' accennato via email, le chiamate alle funzioni writeUTF/readUTF della classe DataOutputStream/DataInputStream sono problematiche nel caso in cui si voglia interfacciare il programma con un linguaggio di programmazione diverso da Java, perche' utilizzano un encoding UTF8 modificato
Fonte: [https://docs.oracle.com/javase/7/docs/api/java/io/DataOutputStream.html#writeUTF(java.lang.String)](https://docs.oracle.com/javase/7/docs/api/java/io/DataOutputStream.html#writeUTF(java.lang.String))

Per risolvere il problema, ho sostituito le chiamate con una versione alternativa che utilizza un encoding UTF8 standard.
Ho testato il funzionamento delle nuove chiamate ed il sistema si comporta come previsto. La modifica comunque e' risultata molto circoscritta, coinvolgendo in totale 8 chiamate.

Cordiali saluti,
Federico Terzi