### PR TITLE
Log-replay-and-gui-fix

### DIFF
--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/gui/Background.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/gui/Background.java
@@ -3,11 +3,11 @@ package it.unibo.ai.didattica.competition.tablut.gui;
 import java.awt.Graphics;
 import java.awt.Image;
 
-import javax.swing.JFrame;
+import javax.swing.*;
 
 import it.unibo.ai.didattica.competition.tablut.domain.State;
 
-public abstract class Background extends JFrame {
+public abstract class Background extends JPanel {
 	
 	/**
 	 * 
@@ -34,8 +34,8 @@ public abstract class Background extends JFrame {
 	}
 	
 	@Override
-	public void paint( Graphics g ) { 
-	    super.paint(g);
+	public void paintComponent( Graphics g ) {
+	    super.paintComponent(g);
 	    g.drawImage(background, 10, 30, null);
 	    for(int i=0;i<this.aState.getBoard().length;i++)
 	    {

--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/gui/Gui.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/gui/Gui.java
@@ -12,7 +12,8 @@ import it.unibo.ai.didattica.competition.tablut.domain.State;
  */
 public class Gui {
 	
-	Background frame;
+	Background background;
+	JFrame frame;
 	private int game;
 	
 	public Gui(int game) {
@@ -28,7 +29,7 @@ public class Gui {
 	 * @param aState represent the new state of the game
 	 */
 	public void update(State aState) {
-		frame.setaState(aState);
+		background.setaState(aState);
 		frame.repaint();
 	}	
 	
@@ -38,29 +39,30 @@ public class Gui {
 	private void initGUI() {
 		switch (this.game) {
 		case 1:
-			frame = new BackgroundTablut();
-			frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-			frame.setSize(280, 300);
+			background = new BackgroundTablut();
 			break;
 		case 2:
-			frame = new BackgroundTablut();
-			frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-			frame.setSize(280, 300);
+			background = new BackgroundTablut();
 			break;
 		case 3:
-			frame = new BackgroundBrandub();
-			frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-			frame.setSize(280, 300);
+			background = new BackgroundBrandub();
 			break;
 		case 4:
-			frame = new BackgroundTablut();
-			frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-			frame.setSize(280, 300);
+			background = new BackgroundTablut();
 			break;
 		default:
 			System.out.println("Error in GUI init");
 			System.exit(4);
 		}
+
+		frame = new JFrame();
+		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		// Più performante fare paint su
+		// JPanel (cioè background) che
+		// direttamente sul frame
+		frame.getContentPane().add(background);
+		frame.pack();
+		frame.setLocationByPlatform(true);
 	}
 	
 	/**
@@ -69,22 +71,22 @@ public class Gui {
 	private void show() {
 		switch (game) {
 		case 1:
-			frame.setSize(370, 395);
+			frame.setSize(415, 415);
 			frame.setTitle("ClassicTablut");
 			frame.setVisible(true);
 			break;
 		case 2:
-			frame.setSize(370, 395);
+			frame.setSize(415, 415);
 			frame.setTitle("ModernTablut");
 			frame.setVisible(true);
 			break;
 		case 3:
-			frame.setSize(300, 330);
+			frame.setSize(415, 415);
 			frame.setTitle("Brandub");
 			frame.setVisible(true);
 			break;
 		case 4:
-			frame.setSize(370, 395);
+			frame.setSize(390, 435);
 			frame.setTitle("Tablut");
 			frame.setVisible(true);
 			break;

--- a/Tablut/src/it/unibo/ai/didattica/competition/tablut/server/ReplayServer.java
+++ b/Tablut/src/it/unibo/ai/didattica/competition/tablut/server/ReplayServer.java
@@ -1,0 +1,159 @@
+package it.unibo.ai.didattica.competition.tablut.server;
+
+import it.unibo.ai.didattica.competition.tablut.domain.*;
+
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Replays the results of previous game
+ * by loading the state from game log
+ * Ideally for use with GUI
+ *
+ * @author Filippo Lenzi
+ *
+ */
+public class ReplayServer extends Server {
+	protected String replayFilePath;
+	protected int timeBetweenTurns = 500; // ms
+	protected boolean initializedGui = false;
+
+	public ReplayServer(String replayFilePath, int cacheSize, int numErrors, int repeated, int game, boolean gui) {
+		super(Integer.MAX_VALUE, cacheSize, numErrors, repeated, game, gui);
+		this.replayFilePath = replayFilePath;
+	}
+
+	@Override
+	public void run() {
+		try (BufferedReader reader = new BufferedReader(new FileReader(replayFilePath))) {
+			parseReader(reader);
+		} catch (IOException e) {
+			e.printStackTrace();
+			System.exit(-1);
+		}
+	}
+
+	/*
+	File format:
+	[...]
+	mag 16, 2022 5:14:16 PM it.unibo.ai.didattica.competition.tablut.domain.GameAshtonTablut checkMove
+	BUONO: Turn: W Pawn from b9 to a9
+	mag 16, 2022 5:14:16 PM it.unibo.ai.didattica.competition.tablut.domain.GameAshtonTablut movePawn
+	BUONO: Movimento pedina
+	mag 16, 2022 5:14:16 PM it.unibo.ai.didattica.competition.tablut.domain.GameAshtonTablut checkMove
+	BUONO: Current draw cache size: 8
+	mag 16, 2022 5:14:16 PM it.unibo.ai.didattica.competition.tablut.domain.GameAshtonTablut checkMove
+	BUONO: Stato:
+	OOOOOOOOO
+	OOBOOOBOO
+	OBBBOOBBO
+	OBOOOBOOO
+	OBOOTOOOO
+	OOOBOKOOO
+	OBOOOOBOO
+	OOOOOOBOO
+	WOOOOOOOO
+	-
+	B
+	[...]
+	 */
+
+	protected void parseReader(BufferedReader reader) throws IOException {
+		final int stateNumLines = 9;
+		List<String> currentStateLines = null;
+		Pattern stateLinePattern = Pattern.compile("[OBWKT]{9}");
+		String line;
+		boolean nextIsState = false;
+		int linesUntilTurn = -1;
+		State.Turn lastTurn = State.Turn.WHITE;
+
+		while ((line = reader.readLine()) != null) {
+			line = line.strip();
+
+			if (linesUntilTurn >= 0) {
+				linesUntilTurn--;
+				if (linesUntilTurn == 0) {
+					String finalLine = line; // lambda java
+					lastTurn = Arrays.stream(State.Turn.values())
+							.filter(t -> t.toString().equals(finalLine))
+							.findAny().get();
+				}
+			}
+
+			if (nextIsState) {
+				Matcher stateLineMatcher = stateLinePattern.matcher(line);
+				if (stateLineMatcher.matches()) {
+					currentStateLines.add(line);
+					// Completed state
+					if (currentStateLines.size() >= stateNumLines) {
+						State state = getStateFromLines(currentStateLines, lastTurn);
+						runTurn(state);
+						nextIsState = false;
+						linesUntilTurn = 2;
+					}
+				} else {
+					throw new RuntimeException("Wrong file format! Expected state line, found: " + line);
+				}
+			}
+
+			if (line.endsWith("Stato:")) {
+				nextIsState = true;
+				currentStateLines = new ArrayList<>(9);
+			}
+		}
+	}
+
+	protected State getStateFromLines(List<String> lines, State.Turn turn) {
+		State state;
+		switch (this.gameC) {
+			case 1, 2, 4 -> state = new StateTablut();
+			case 3 -> state = new StateBrandub();
+			default -> throw new IllegalStateException("Wrong gameC somehow!");
+		}
+		State.Pawn[][] board = state.getBoard();
+
+		if (lines.size() != 9)
+			throw new IllegalArgumentException(String.format("Wrong number of lines: was %d, expected 9", lines.size()));
+
+		for (int i = 0; i < lines.size(); i++) {
+			String line = lines.get(i);
+			if (line.length() != 9)
+				throw new IllegalArgumentException(String.format("Wrong line length at line %d: was %d, expected 9", i, line.length()));
+			for (int j = 0; j < line.length(); j++) {
+				String pawnChar = "" + line.charAt(j);
+
+				State.Pawn pawn = State.Pawn.fromString(pawnChar);
+				board[i][j] = pawn;
+			}
+		}
+
+		state.setTurn(turn);
+		state.setBoard(board);
+
+		return state;
+	}
+
+	protected void runTurn(State state) {
+		if (enableGui) {
+			if (initializedGui) {
+				theGui.update(state);
+			} else {
+				initializeGUI(state);
+				initializedGui = true;
+			}
+		}
+		try {
+			Thread.sleep(timeBetweenTurns);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+}


### PR DESCRIPTION
Aggiunta di funzionalità di replay al server, che permette di riprodurre una partita precedente tramite il suo log, con lo scopo di registrarla in tempi più veloci. Inoltre, GUI migliorata per evitare flash bianco ad ogni turno.

Esempio di uso:
```
java -jar .\server.jar -g -R .\logs\PLAYER1_vs_PLAYER2_1652711382324_gameLog.txt
```
Ho inviato anche una email nella posta universitaria a riguardo.